### PR TITLE
created 'GIT_TAG' variable

### DIFF
--- a/src/popper/config.py
+++ b/src/popper/config.py
@@ -55,6 +55,7 @@ class ConfigLoader(object):
             "git_sha_short": scm.get_sha(repo, short=7),
             "git_branch": scm.get_branch(repo),
             "git_remote_origin_url": scm.get_remote_url(repo),
+            "git_tag": scm.get_tag(repo),
             # wid is used to associate a unique id to this workspace. This is then
             # used by runners to name resources in a way that there is no name
             # clash between concurrent workflows being executed

--- a/src/popper/runner.py
+++ b/src/popper/runner.py
@@ -226,6 +226,7 @@ class StepRunner(object):
                     "GIT_BRANCH": self._config.git_branch,
                     "GIT_SHA_SHORT": self._config.git_sha_short,
                     "GIT_REMOTE_ORIGIN_URL": self._config.git_remote_origin_url,
+                    "GIT_TAG": self._config.git_tag,
                 }
             )
         return step_env

--- a/src/popper/scm.py
+++ b/src/popper/scm.py
@@ -198,3 +198,11 @@ def get_branch(repo):
         return branch
 
     return get_sha(repo)
+
+
+def get_tag(repo=None):
+    """Obtains the git tag fot the currently checked our version on the given repository object
+        if possible, otherwise returns ""
+    """
+    if repo:
+        return repo.describe('--tags', '--dirty','--broken', '--long')

--- a/src/test/test_runner.py
+++ b/src/test/test_runner.py
@@ -126,6 +126,7 @@ class TestStepRunner(PopperTest):
                 "GIT_BRANCH": conf.git_branch,
                 "GIT_SHA_SHORT": conf.git_sha_short,
                 "GIT_REMOTE_ORIGIN_URL": conf.git_remote_origin_url,
+                "GIT_TAG": conf.git_tag,
             }
             self.assertDictEqual(expected, env)
             os.environ.pop("A")


### PR DESCRIPTION
this is the first approach to the git_tag variable, I might being dismissing some scenarios in the [get_tag](https://github.com/DanielOsunaV/popper/blob/0275cc4ad603f6f8149d92fa9896a7d20e7bac2b/src/popper/scm.py#L203) function, If you find some dismissing scenarios let me know and I'll be happy to make the changes onto the function