### PR TITLE
fix: corrected syntax of example workflows

### DIFF
--- a/examples/cd/ansible.yml
+++ b/examples/cd/ansible.yml
@@ -7,6 +7,6 @@ steps:
   env:
     ANSIBLE_LOG_PATH: ./ansible.log
     ANSIBLE_SSH_CONTROL_PATH: /dev/shm/cp%%h-%%p-%%r
-    ANSIBLE_HOST_KEY_CHECKING: false
+    ANSIBLE_HOST_KEY_CHECKING: "false"
   secrets:
   - ANSIBLE_SSH_KEY_DATA

--- a/examples/ci/go.yml
+++ b/examples/ci/go.yml
@@ -3,10 +3,10 @@ steps:
   uses: docker://golang:1.14.4-alpine3.11
   args: [go, get, -v, -t, -d, ./...]
 
-- name: build
+- id: build
   uses: docker://golang:1.14.4-alpine3.11
   args: [go, build, -v, .]
 
-- name: test
+- id: test
   uses: docker://golang:1.14.4-alpine3.11
   args: [go, test, -v, .]


### PR DESCRIPTION
This fix is as regards the issue opened at #890 