### PR TITLE
Allow spaces in step IDs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ docker run --rm -ti \
   --volume "$PWD":"$PWD" \
   --workdir "$PWD" \
   --env-file /tmp/.envfile \
-  getpopper/popper:v2.7.0 $@
+  getpopper/popper:v2.7.0 "$@"
 EOF
 
 if [ "$?" -eq 0 ]; then


### PR DESCRIPTION
The call to `docker` must receive the command-line arguments verbatim,
including quotes. Therefore `$@` needs to be quoted.

Without quotes (before):
`popper run -f wf.yml "first step"`
would execute:
`docker run <...> getpopper/popper:v2.7.0 run -f wf.yml first step`

With quotes (after fix):
`docker run <...>  getpopper/popper:v2.7.0 run -f wf.yml "first step"`