### PR TITLE
Add error message that Singularity needs PIP

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,13 @@ command -v docker >/dev/null 2>&1 || { echo >&2 "docker command not found. Abort
 cat > ./popper << "EOF"
 #!/usr/bin/env sh
 
+if echo "$@" | grep '\e\s*singularity\|--engine\s*singularity'; then
+  echo >&2 'Singularity is not supported.',
+  echo >&2 'Please install Popper as a Python Package. Instructions can be found here:'
+  echo >&2 'https://github.com/getpopper/popper/blob/master/docs/installation.md'
+  exit 1
+fi
+
 printenv > /tmp/.envfile
 
 docker run --rm -ti \

--- a/install.sh
+++ b/install.sh
@@ -37,13 +37,6 @@ command -v docker >/dev/null 2>&1 || { echo >&2 "docker command not found. Abort
 cat > ./popper << "EOF"
 #!/usr/bin/env sh
 
-if echo "$@" | grep '\e\s*singularity\|--engine\s*singularity'; then
-  echo >&2 'Singularity is not supported.',
-  echo >&2 'Please install Popper as a Python Package. Instructions can be found here:'
-  echo >&2 'https://github.com/getpopper/popper/blob/master/docs/installation.md'
-  exit 1
-fi
-
 printenv > /tmp/.envfile
 
 docker run --rm -ti \

--- a/src/popper/runner_host.py
+++ b/src/popper/runner_host.py
@@ -313,15 +313,17 @@ class SingularityRunner(StepRunner):
         self._s = None
 
         if SingularityRunner._in_docker():
-            log.fail((
-                "You seem to be running Popper in a Docker container.\n"
-                "Singularity cannot be executed this way.\n"
-                "Either run Popper without Singularity or install Popper "
-                "through PIP.\n"
-                "Instructions are available here:\n"
-                "https://github.com/getpopper/popper/"
-                "blob/master/docs/installation.md"
-            ))
+            log.fail(
+                (
+                    "You seem to be running Popper in a Docker container.\n"
+                    "Singularity cannot be executed this way.\n"
+                    "Either run Popper without Singularity or install Popper "
+                    "through PIP.\n"
+                    "Instructions are available here:\n"
+                    "https://github.com/getpopper/popper/"
+                    "blob/master/docs/installation.md"
+                )
+            )
 
         if self._config.reuse:
             log.fail("Reuse not supported for SingularityRunner.")
@@ -375,9 +377,9 @@ class SingularityRunner(StepRunner):
     @staticmethod
     def _in_docker():
         """ Returns TRUE if we are being executed in a Docker container. """
-        if os.path.isfile('/proc/1/cgroup'):
-            with open('/proc/1/cgroup', 'r') as f:
-                return 'docker' in f.read() or 'lxc' in f.read()
+        if os.path.isfile("/proc/1/cgroup"):
+            with open("/proc/1/cgroup", "r") as f:
+                return "docker" in f.read() or "lxc" in f.read()
 
     def _build_from_recipe(self, build_ctx_path, build_dest, cid):
         SingularityRunner.lock.acquire()

--- a/src/popper/runner_host.py
+++ b/src/popper/runner_host.py
@@ -312,6 +312,17 @@ class SingularityRunner(StepRunner):
         self._spawned_containers = set()
         self._s = None
 
+        if SingularityRunner._in_docker():
+            log.fail((
+                "You seem to be running Popper in a Docker container.\n"
+                "Singularity cannot be executed this way.\n"
+                "Either run Popper without Singularity or install Popper "
+                "through PIP.\n"
+                "Instructions are available here:\n"
+                "https://github.com/getpopper/popper/"
+                "blob/master/docs/installation.md"
+            ))
+
         if self._config.reuse:
             log.fail("Reuse not supported for SingularityRunner.")
 
@@ -360,6 +371,13 @@ class SingularityRunner(StepRunner):
             return SingularityRunner._convert(dockerfile, singularityfile)
         else:
             log.fail("No Dockerfile was found.")
+
+    @staticmethod
+    def _in_docker():
+        """ Returns TRUE if we are being executed in a Docker container. """
+        if os.path.isfile('/proc/1/cgroup'):
+            with open('/proc/1/cgroup', 'r') as f:
+                return 'docker' in f.read() or 'lxc' in f.read()
 
     def _build_from_recipe(self, build_ctx_path, build_dest, cid):
         SingularityRunner.lock.acquire()


### PR DESCRIPTION
It says it in the `README.md` that Singularity is not supported by
Popper installed through `install.sh`, but not every user has read it.

This fixes part of #898.