### PR TITLE
cli: modify way in which empty git repos are identified

### DIFF
--- a/src/popper/runner.py
+++ b/src/popper/runner.py
@@ -226,7 +226,8 @@ class StepRunner(object):
                     "GIT_BRANCH": self._config.git_branch,
                     "GIT_SHA_SHORT": self._config.git_sha_short,
                     "GIT_REMOTE_ORIGIN_URL": self._config.git_remote_origin_url,
-                    "GIT_TAG": self._config.git_tag,
+                    # git_tag might be None, so we use empty string instead
+                    "GIT_TAG": self._config.get("git_tag", ""),
                 }
             )
         return step_env

--- a/src/popper/runner_host.py
+++ b/src/popper/runner_host.py
@@ -63,6 +63,7 @@ class HostRunner(StepRunner):
     @staticmethod
     def _exec_cmd(cmd, env=None, cwd=os.getcwd(), pids=set(), logging=True):
         pid = 0
+        ecode = None
         try:
             with Popen(
                 cmd,
@@ -91,7 +92,8 @@ class HostRunner(StepRunner):
 
         except SubprocessError as ex:
             output = ""
-            ecode = ex.returncode
+            if not ecode:
+                ecode = 1
             log.step_info(f"Command '{cmd[0]}' failed with: {ex}")
         except Exception as ex:
             output = ""

--- a/src/popper/scm.py
+++ b/src/popper/scm.py
@@ -164,7 +164,7 @@ def parse(url):
 
 
 def is_empty(repo):
-    """Whether the currently checked out branch at least one commit"""
+    """True if the currently checked out branch has no commits."""
     return repo.git.rev_list("-n 1", "--all") == ""
 
 

--- a/src/popper/scm.py
+++ b/src/popper/scm.py
@@ -18,13 +18,16 @@ def new_repo(gitrepo_dir=None):
     """
     if not gitrepo_dir or not os.path.isdir(gitrepo_dir):
         return None
+
+    repo = None
+
     try:
         repo = git.Repo(gitrepo_dir, search_parent_directories=True)
     except git.InvalidGitRepositoryError:
         # Optimistically assume that this is due to .git/ folder not existing
         pass
 
-    if is_empty(repo):
+    if not repo or is_empty(repo):
         return None
 
     return repo


### PR DESCRIPTION
Small tweak on how empty Git repos are identified. Uses `git rev-list -n 1 -all` to check if there are commits in the currently checked out branch. 