### PR TITLE
Issue #928: Suggesting a fix for non-default hostPath volumes

### DIFF
--- a/docs/sections/cn_workflows.md
+++ b/docs/sections/cn_workflows.md
@@ -440,6 +440,10 @@ All the available configuration options have been described below:
   If this option is not provided, Popper will leave the task of scheduling the pods upon Kubernetes. 
   The exception to this is, when both the `pod_host_node` and `persistent_volume_name` options are not provided, Popper will try to find out a pod and schedule all the pods (init-pods + step-pods) on that node to use the `HostPath` persistent volume of 1GB which will be automatically created.
 
+* `hostpathvol_path`: The path to use for creating a HostPath volume. If not provided, /tmp will be used.
+
+* `hostpathvol_size`: The size of the HostPath volume. If not provided, 1GB will be used.
+
 To run workflows on Kubernetes:
 
 ```bash

--- a/src/popper/runner_kubernetes.py
+++ b/src/popper/runner_kubernetes.py
@@ -263,16 +263,22 @@ class KubernetesRunner(StepRunner):
     def _vol_create(self, volume_name):
         """Create a default PersistentVolume of hostPath type.
         """
+        hostpathvol_path = "/tmp"
+        hostpathvol_size = "1Gi"
+        if self._config.resman_opts.get("hostpathvol_path", None):
+            hostpathvol_path = self._config.resman_opts.hostpathvol_path
+        if self._config.resman_opts.get("hostpathvol_size", None):
+            hostpathvol_size = self._config.resman_opts.hostpathvol_size
         vol_conf = {
             "kind": "PersistentVolume",
             "apiVersion": "v1",
-            "metadata": {"name": volume_name, "labels": {"type": "host"},},
+            "metadata": {"name": volume_name, "labels": {"type": "host"}},
             "spec": {
                 "persistentVolumeReclaimPolicy": "Recycle",
                 "storageClassName": "manual",
-                "capacity": {"storage": "1Gi",},
+                "capacity": {"storage": hostpathvol_size,},
                 "accessModes": ["ReadWriteMany"],
-                "hostPath": {"path": "/tmp"},
+                "hostPath": {"path": hostpathvol_path},
             },
         }
 


### PR DESCRIPTION
Allows users to use options to specify non-default path and volume size in the config file. Added these new options to the documentation (cn_workflows.md).