### PR TITLE
Fix #927: Prevent trying to schedule on master nodes first

### DIFF
--- a/src/popper/runner_kubernetes.py
+++ b/src/popper/runner_kubernetes.py
@@ -116,7 +116,10 @@ class KubernetesRunner(StepRunner):
                 node_role = ""
                 if node.spec.taints and len(node.spec.taints) > 0:
                     node_role = node.spec.taints[0].key
-                if node_role != "node-role.kubernetes.io/master" and node_role != "node-role.kubernetes.io/unreachable":
+                if (
+                    node_role != "node-role.kubernetes.io/master"
+                    and node_role != "node-role.kubernetes.io/unreachable"
+                ):
                     nodes.insert(0, node.metadata.labels["kubernetes.io/hostname"])
                 else:
                     nodes.insert(


### PR DESCRIPTION
Based off of what the description of the issue said and the generous aid from slack this is my current idea for the solution to this problem. I

Seeing as the base premise involved re-ordering the list of nodes I assumed the order was of little consequence aside from having masters last so the non-master nodes will be ordered differently than before.  Furthermore, I considered having two arrays that just got connected after iterating through the nodes but I was unsure if you guys would want to just keep it one array the whole time for cleanliness.

If I have done anything incorrectly or there are issues of cleanliness or efficiency just let me know.