### PR TITLE
fix: do not fail on bool docker opts when substituting

### DIFF
--- a/src/popper/parser.py
+++ b/src/popper/parser.py
@@ -137,11 +137,10 @@ class WorkflowParser(object):
                     used_registry[k] = 1
 
         elif isinstance(wf_element, dict):
-            # we assume map of strings
             for ek in wf_element:
                 if k in ek:
                     log.fail("Substitutions not allowed on dictionary keys")
-                if k in wf_element[ek]:
+                if type(wf_element[ek]) == str and k in wf_element[ek]:
                     log.debug(f"Applying substitution to value associated to key {k}")
                     wf_element[ek] = wf_element[ek].replace(k, v)
                     used_registry[k] = 1

--- a/src/test/test_parser.py
+++ b/src/test/test_parser.py
@@ -139,6 +139,31 @@ class TestWorkflow(unittest.TestCase):
             **{"wf_data": wf_data, "substitutions": ["SUB1=WRONG"]}
         )
 
+        # allow non-str values
+        wf_data = {
+            "steps": [
+                {
+                    "uses": "some_image",
+                    "id": "some_$_DUMMY",
+                    "env": {"FOO": "BAR"},
+                    "secrets": ["a-secret"],
+                    "options": {"auto_remove": True},
+                }
+            ]
+        }
+        substitutions = [
+            "_DUMMY=dummy",
+        ]
+        wf = WorkflowParser.parse(
+            wf_data=wf_data, substitutions=substitutions, allow_loose=True
+        )
+        step = wf.steps[0]
+        self.assertEqual("some_image", step.uses)
+        self.assertEqual("some_dummy", step.id)
+        self.assertEqual("BAR", step.env["FOO"])
+        self.assertEqual(("a-secret",), step.secrets)
+        self.assertEqual({"auto_remove": True}, step.options)
+
         # expect error when not all given subs are used
         wf_data = {
             "steps": [


### PR DESCRIPTION
This should solve #968, i.e. popper will no longer fail on boolean values when substituting.