### PR TITLE
cli: retain workspace volume when volumes option is set

### DIFF
--- a/src/popper/runner.py
+++ b/src/popper/runner.py
@@ -304,7 +304,7 @@ class StepRunner(object):
             "image": img,
             "command": list(step.args),
             "name": name,
-            "volumes": [f"{self._config.workspace_dir}:/workspace:Z",],
+            "volumes": [],
             "working_dir": step.dir if step.dir else "/workspace",
             "environment": self._prepare_environment(step),
             "entrypoint": step.runs if step.runs else None,
@@ -315,6 +315,14 @@ class StepRunner(object):
 
         self._update_with_engine_config(args)
         args.update(step.options)
+
+        if "volumes" not in args:
+            args["volumes"] = []
+        else:
+            args["volumes"] = list(args["volumes"])
+
+        args["volumes"].append(f"{self._config.workspace_dir}:/workspace:Z")
+
         log.debug(f"container args: {pu.prettystr(args)}\n")
 
         return args


### PR DESCRIPTION
Currently the workspace bind mount is overwritten when setting the volumes property in the steps' options field.

Popper Version: 2020.09.1

Minimal Working Example:
```sh
$ cat wf.yml
steps:

- uses: "docker://alpine:3.11"
  options:
    volumes:
     - /dev/zero:/tmp/test
  args: ["cat", "wf.yml"]

$ popper run -f wf.yml
[1] docker pull alpine:3.11
[1] docker create name=popper_1_c25e08ff image=alpine:3.11 command=['cat', 'wf.yml']
[1] docker start
cat: can't open 'wf.yml': No such file or directory
ERROR: Step '1' failed ('1') !
```

This behavior can be worked around by using docker-py's mount option instead of the volumes option, but the behavior of the volumes option seems unintuitive to me.

This pull request retains the workspace mount, by appending it to the volumes list after the update call with the step specific options.

In case anyone else stumbles over this behavior before this behavior is changed (or if the behavior is intentional) the following workflow works as intended. However, keep in mind that the mounts option requires you to specify the mount type, which would be inferred when using the volumes option.
```yml
steps:

- uses: "docker://alpine:3.11"
  options:
    mounts:
    - { 'source': '/dev/zero', 'target': '/tmp/test', 'type': 'bind', 'read_only': false }
  args: ["cat", "wf.yml"]
```