### PR TITLE
feat: remove containers cli flag

### DIFF
--- a/src/popper/commands/cmd_run.py
+++ b/src/popper/commands/cmd_run.py
@@ -50,6 +50,12 @@ from popper.runner import WorkflowRunner
     is_flag=True,
 )
 @click.option(
+    "--remove",
+    help="Remove containers after execution.",
+    required=False,
+    is_flag=True,
+)
+@click.option(
     "-e",
     "--engine",
     help="Specify container engine used to execute workflow steps.",
@@ -127,6 +133,7 @@ def cli(
     log_file,
     quiet,
     reuse,
+    remove,
     engine,
     resource_manager,
     skip,
@@ -184,6 +191,7 @@ def cli(
         resman_name=resource_manager,
         config_file=conf,
         reuse=reuse,
+        remove=remove,
         dry_run=dry_run,
         skip_pull=skip_pull,
         skip_clone=skip_clone,

--- a/src/popper/config.py
+++ b/src/popper/config.py
@@ -17,6 +17,7 @@ class ConfigLoader(object):
         config_file=None,
         workspace_dir=os.getcwd(),
         reuse=False,
+        remove=False,
         dry_run=False,
         quiet=False,
         skip_pull=False,
@@ -44,6 +45,7 @@ class ConfigLoader(object):
         pp_config = {
             "workspace_dir": workspace_dir,
             "reuse": reuse,
+            "remove": remove,
             "dry_run": dry_run,
             "quiet": quiet,
             "skip_pull": skip_pull,

--- a/src/popper/runner_host.py
+++ b/src/popper/runner_host.py
@@ -28,6 +28,9 @@ class HostRunner(StepRunner):
         if self._config.reuse:
             log.warning("Reuse not supported for HostRunner.")
 
+        if self._config.remove:
+            log.warning("Remove not supported for HostRunner.")
+
     def __enter__(self):
         return self
 
@@ -165,6 +168,9 @@ class DockerRunner(StepRunner):
                     log.step_info(line.decode().rstrip())
 
             e = container.wait()["StatusCode"]
+
+            if self._config.remove:
+                container.remove(force=True)
         except Exception as exc:
             log.fail(exc)
         return e
@@ -253,6 +259,9 @@ class PodmanRunner(StepRunner):
 
     def __init__(self, init_podman_client=True, **kw):
         super(PodmanRunner, self).__init__(**kw)
+
+        if self._config.remove:
+            log.warning("Remove not supported for PodmanRunner.")
 
         self._spawned_containers = set()
 

--- a/src/popper/runner_slurm.py
+++ b/src/popper/runner_slurm.py
@@ -152,6 +152,8 @@ class SingularityRunner(SlurmRunner, HostSingularityRunner):
         super(SingularityRunner, self).__init__(init_spython_client=False, **kw)
         if self._config.reuse:
             log.fail("Reuse not supported for SingularityRunner.")
+        if self._config.remove:
+            log.fail("Remove not supported for SingularityRunner.")
 
         singularity_executables = ["singularity"]
         for exe in singularity_executables:

--- a/src/test/test_config.py
+++ b/src/test/test_config.py
@@ -30,6 +30,7 @@ class TestPopperConfig(PopperTest):
                 "workspace_dir": os.getcwd(),
                 "quiet": False,
                 "reuse": False,
+                "remove": False,
                 "pty": False,
                 "allow_undefined_secrets_in_ci": False,
             },
@@ -46,6 +47,7 @@ class TestPopperConfig(PopperTest):
             "workspace_dir": os.path.realpath("/tmp/foo"),
             "quiet": True,
             "reuse": True,
+            "remove": True,
             "pty": True,
             "allow_undefined_secrets_in_ci": True,
         }


### PR DESCRIPTION
Add CLI option to remove each workflow container after it has finished (docker engine).

Use case: Do not clutter your docker daemon with stopped containers, if you do not need the containers afterwards.