### PR TITLE
support `env` options in translator_drone

### DIFF
--- a/src/popper/translators/translator_drone.py
+++ b/src/popper/translators/translator_drone.py
@@ -8,10 +8,23 @@ class DroneTranslator(WorkflowTranslator):
 
     def translate(self, wf):
         box = Box(kind="pipeline", type="docker", name="default")
-        box["steps"] = [self._translate_step(step) for step in wf["steps"]]
+
+        # environment variables available throughout the pipeline
+        wf_env = {
+            "GIT_COMMIT": "${DRONE_COMMIT_SHA}",
+            "GIT_BRANCH": "${DRONE_COMMIT_BRANCH}",
+            "GIT_SHA_SHORT": "${DRONE_COMMIT_SHA:0:7}",
+            "GIT_REMOTE_ORIGIN_URL": "${DRONE_GIT_HTTP_URL}",
+            "GIT_TAG": "${DRONE_TAG}",
+        }
+
+        if "options" in wf:
+            if "env" in wf["options"]:
+                wf_env = {**wf["options"]["env"], **wf_env}
+        box["steps"] = [self._translate_step(step, wf_env) for step in wf["steps"]]
         return box.to_yaml()
 
-    def _translate_step(self, popper_step):
+    def _translate_step(self, popper_step, wf_env):
         drone_step = Box()
         drone_step["image"] = self._translate_uses(popper_step["uses"])
         drone_step["name"] = popper_step["id"]
@@ -19,6 +32,13 @@ class DroneTranslator(WorkflowTranslator):
             drone_step["command"] = list(popper_step["args"])
         if "runs" in popper_step:
             drone_step["entrypoint"] = list(popper_step["runs"])
+
+        # because Drone only supports environment variables per pipeline in Docker pipelines, set variables in each step
+        if "env" in popper_step:
+            # if per-step variables are defined, merge them with pipeline-wide variables
+            drone_step["environment"] = {**wf_env, **dict(popper_step["env"])}
+        else:
+            drone_step["environment"] = wf_env
         return drone_step
 
     def _translate_uses(self, uses):


### PR DESCRIPTION
## Overview

This PR adds support for environment variable options in Popper-to-Drone translator. 

## `env` options

Popper has the `env` option to set environment variables in the workflow. You can place `env` under `steps` to define variables for a step, or you can place `env` under `options` to define variables throughout the steps.

Drone has a similar feature `environment` and has almost identical syntax for defining environment variables. However, [it only supports per-pipeline variables](https://docs.drone.io/pipeline/environment/syntax/#:~:text=variables-,Per%20Pipeline,Drone,-supports) (equivalent of `options.env`) in Docker pipelines.

Hence, I made a decision to inject global variables in each step.

## `GIT_` Variables

Popper injects multiple variables that represent the status of the git repository. The translator automatically generates definitions of such environment variables in Drone so that scripts written for Popper can continue to work.

The following is the list of variables supported by Popper and corresponding Drone template variables.

| Popper | [Drone](https://docs.drone.io/pipeline/environment/reference/) |
|---|---|
| `GIT_COMMIT` | `${DRONE_COMMIT_SHA}` |
| `GIT_BRANCH` | `${DRONE_COMMIT_BRANCH}` |
| `GIT_SHA_SHORT` | `${DRONE_COMMIT_SHA:0:7}` |
| `GIT_REMOTE_ORIGIN_URL` | `${DRONE_GIT_HTTP_URL}` |
| `GIT_TAG` | `${DRONE_TAG}` |

The translator automatically generates bindings and injects them into the output.
