### PR TITLE
List `translators` package in `setup.py`

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="ivotron@ucsc.edu",
     url="https://getpopper.io",
     description="Popper CLI tool to generate reproducible papers.",
-    packages=["popper", "popper.commands"],
+    packages=["popper", "popper.commands", "popper.translators"],
     include_package_data=True,
     install_requires=[
         "click==7.1.2",


### PR DESCRIPTION
As stated in [the document](https://docs.python.org/3/distutils/setupscript.html#listing-whole-packages), `popper.translators` must be listed in `packages` in `setup.py` to correctly link packages during the installation.

closes #977

