### PR TITLE
Translate `uses: sh` workflows into Drone's Exec Pipeline

### DIFF
--- a/src/popper/commands/cmd_translate.py
+++ b/src/popper/commands/cmd_translate.py
@@ -1,5 +1,6 @@
 import click
 import os
+import traceback
 
 from popper.cli import pass_context, log
 from popper.parser import WorkflowParser
@@ -38,7 +39,11 @@ def cli(ctx, from_fmt, file, to_fmt):
         outfile = ".drone.yml"
     translator = WorkflowTranslator.get_translator(to_fmt)
     wf = WorkflowParser.parse(file=file)
-    translated = translator.translate(wf)
+    try:
+        translated = translator.translate(wf)
+    except Exception as e:
+        log.debug(traceback.format_exc())
+        log.fail(e)
     with open(outfile, "w") as f:
         f.write(translated)
     log.info(f"Translated to {to_fmt} configuration successfully.")

--- a/src/popper/translators/translator_drone.py
+++ b/src/popper/translators/translator_drone.py
@@ -7,7 +7,10 @@ class DroneTranslator(WorkflowTranslator):
         super().__init__()
 
     def translate(self, wf):
-        box = Box(kind="pipeline", type="docker", name="default")
+        # get workflow type (Docker or Exec)
+        wf_type = self._detect_type(wf)
+
+        box = Box(kind="pipeline", type=wf_type, name="default")
 
         # environment variables available throughout the pipeline
         wf_env = {
@@ -15,23 +18,58 @@ class DroneTranslator(WorkflowTranslator):
             "GIT_BRANCH": "${DRONE_COMMIT_BRANCH}",
             "GIT_SHA_SHORT": "${DRONE_COMMIT_SHA:0:7}",
             "GIT_REMOTE_ORIGIN_URL": "${DRONE_GIT_HTTP_URL}",
-            "GIT_TAG": "${DRONE_TAG}",
+            "GIT_TAG": "${DRONE_TAG}:-''",  # use the empty string if the variable is undefined
         }
 
         if "options" in wf:
             if "env" in wf["options"]:
                 wf_env = {**wf["options"]["env"], **wf_env}
-        box["steps"] = [self._translate_step(step, wf_env) for step in wf["steps"]]
+        box["steps"] = [
+            self._translate_step(step, wf_type, wf_env) for step in wf["steps"]
+        ]
         return box.to_yaml()
 
-    def _translate_step(self, popper_step, wf_env):
+    # given a popper workflow, detect the corresponding Drone's pipeline type
+    def _detect_type(self, wf):
+        if not wf["steps"]:
+            raise AttributeError("`steps` must not be empty")
+
+        # helper function that detects the type from Popper's `uses` field
+        def detect_type(uses):
+            if "docker://" in uses:
+                return "docker"
+            if uses == "sh":
+                return "exec"
+            raise AttributeError(f"Unexpected value {uses} found in `uses` attribute")
+
+        # determine the types of each Popper step
+        ts = [detect_type(step["uses"]) for step in wf["steps"]]
+
+        # make sure all types are the same
+        for t in ts[1:]:
+            if ts[0] != t:
+                raise AttributeError(
+                    "Drone supports only one runner type per pipeline. Popper workflows that use both `sh` and Docker images cannot be translated."
+                )
+        return ts[0]
+
+    def _translate_step(self, popper_step, wf_type, wf_env):
         drone_step = Box()
-        drone_step["image"] = self._translate_uses(popper_step["uses"])
         drone_step["name"] = popper_step["id"]
-        if "args" in popper_step:
-            drone_step["command"] = list(popper_step["args"])
-        if "runs" in popper_step:
-            drone_step["entrypoint"] = list(popper_step["runs"])
+        if wf_type == "docker":
+            drone_step["image"] = self._translate_uses(popper_step["uses"])
+            if "args" in popper_step:
+                drone_step["command"] = list(popper_step["args"])
+            if "runs" in popper_step:
+                drone_step["entrypoint"] = list(popper_step["runs"])
+        if wf_type == "exec":
+            if not popper_step["runs"]:
+                raise AttributeError("You must specify `runs` attribute for steps")
+
+            # `commands` is an array of strings. Construct the command by concatenating `runs` and `args` and use it as the first and only element
+            drone_step["commands"] = [
+                " ".join(list(popper_step["runs"]) + list(popper_step["args"]))
+            ]
 
         # because Drone only supports environment variables per pipeline in Docker pipelines, set variables in each step
         if "env" in popper_step:


### PR DESCRIPTION
Close #981 

This PR adds support for `uses: sh` in Popper-to-Drone translator.

## Limitations

Drone's pipelines must be executed by one runner, so Popper workflows need to have the same `type` for its all steps.

For example,

```yml
steps:
  - uses: docker://alpine
    runs: ["echo", "command 1"]
  - uses: docker://alpine
    runs: ["echo", "command 2"]
```

this Popper workflow will be translated to `pipeline: docker`.

```yml
steps:
  - uses: sh
    runs: ["echo", "command 1"]
  - uses: sh
    runs: ["echo", "command 2"]
```

this will be translated to `pipeline: exec` workflow.

However, 

```yml
steps:
  - uses: docker://alpine
    runs: ["echo", "command 1"]
  - uses: sh
    runs: ["echo", "command 2"]
```

this cannot be translated and shows an error.