### PR TITLE
Translate `dir` attribute

### DIFF
--- a/src/popper/translators/translator_drone.py
+++ b/src/popper/translators/translator_drone.py
@@ -1,6 +1,6 @@
 from box.box import Box
 from popper.translators.translator import WorkflowTranslator
-import shlex
+from shlex import quote
 
 
 class DroneTranslator(WorkflowTranslator):
@@ -74,7 +74,10 @@ class DroneTranslator(WorkflowTranslator):
                     # cd into the specified directory
                     f"cd {popper_step['dir']}",
                     # run the command
-                    shlex.join(list(popper_step["runs"]) + list(popper_step["args"])),
+                    " ".join(
+                        quote(arg)
+                        for arg in list(popper_step["runs"]) + list(popper_step["args"])
+                    ),
                 ]
             # translate args and runs without modifications
             else:
@@ -88,7 +91,10 @@ class DroneTranslator(WorkflowTranslator):
 
             # `commands` is an array of strings. Construct the command by concatenating `runs` and `args` and use it as the first and only element
             drone_step["commands"] = [
-                shlex.join(list(popper_step["runs"]) + list(popper_step["args"]))
+                " ".join(
+                    quote(arg)
+                    for arg in list(popper_step["runs"]) + list(popper_step["args"])
+                )
             ]
 
         # because Drone only supports environment variables per pipeline in Docker pipelines, set variables in each step

--- a/src/test/test_translator_drone.py
+++ b/src/test/test_translator_drone.py
@@ -268,6 +268,46 @@ class TestDroneTranslator(PopperTest):
             ),
         )
 
+    def test_translate_step_dir(self):
+        dt = DroneTranslator()
+        popper_step = Box(
+            {
+                "id": "download",
+                "uses": "docker://alpine",
+                "dir": "/tmp",
+                "runs": ["touch"],
+                "args": ["file1", "file2"],
+            }
+        )
+        drone_step = dt._translate_step(popper_step, "docker", {})
+        self.assertEqual(
+            drone_step,
+            Box(
+                {
+                    "name": "download",
+                    "image": "alpine",
+                    "commands": [
+                        "ln -s /drone/src /workspace",
+                        "cd /tmp",
+                        "touch file1 file2",
+                    ],
+                    "environment": {},
+                }
+            ),
+        )
+
+        popper_step_dir_without_runs = Box(
+            {
+                "id": "download",
+                "uses": "docker://alpine",
+                "dir": "/tmp",
+                "args": ["echo", "missing runs"],
+            }
+        )
+        with self.assertRaises(AttributeError):
+            # raise an error if `runs` is empty
+            dt._translate_step(popper_step_dir_without_runs, "docker", {})
+
     def test_translate_step_exec(self):
         dt = DroneTranslator()
         popper_step = Box(


### PR DESCRIPTION
## Overview

This PR adds support for `dir` option for Popper-to-Drone translator and makes it possible to run commands in directories other than the root of the repository.

Now the translator is capable of translating [all examples in under `/examples`](https://github.com/getpopper/popper/tree/d7f79f18ed2245b3dd61b7092ca61e4fcfeef9ca/examples) 🎉 

## Strategy

### Changing Directory

Popper's `dir` corresponds to [`--workdir` on Docker](https://docs.docker.com/engine/reference/run/#workdir) under the hood. However, Drone's runner doesn't support running commands other than the project root.

In this PR, the translator inserts a `cd` command before running the commands to change the working directory.

### Absolute Path Access

`dir` options are usually given in absolute path.

https://github.com/getpopper/popper/blob/d7f79f18ed2245b3dd61b7092ca61e4fcfeef9ca/examples/cpp/ci.yml#L16

However, because Popper and Drone mount the repository in different locations (`/workspace` for Popper and `/drone/src` for Drone), we cannot simply `cd` into the specified directory and need a workaround.

In this PR, the translator inserts `ln -s /drone/src /workspace` to make a symbolic link. In this way, the file system will have the same structure and any command that uses an absolute path, including the `cd` command mentioned above, will work as expected.

### Limitations

For the reasons above, we need to execute two commands before running the actual commands. We can use Drone's `commands` attribute to run multiple commands. 

However, in order to use that field, we need to obtain actual commands that will be executed in containers. This is why the translator requires `runs` attribute to be set when using `dir` attribute.

In Popper, if `runs` attribute is not given, it will use the Dockerfile's `ENTRYPOINT`. Because there is no trivial way to obtain `ENTRYPOINT` from docker images, Popper steps with `dir` but without `runs` cannot be translated. Such translations will fail with an error.

## Discussion

While working on this PR, I realized that Popper's host runner (used with `uses: sh`) doesn't respect the `dir` option.

For example,

```yml
steps:
  - id: relative path
    uses: sh
    runs: [/bin/sh, -c]
    dir: /tmp
    args: ["echo 'hello world' > hello.txt"]
```

Running this workflow with `popper run` will create `hello.txt` in the current directory as opposed to `/tmp`.

To match the behavior of an original workflow and translated workflow, the translator does nothing for steps with `uses: sh`.
