### PR TITLE
[Translator] Create TaskTranslator

### DIFF
--- a/src/popper/commands/cmd_translate.py
+++ b/src/popper/commands/cmd_translate.py
@@ -30,13 +30,15 @@ from popper.translators.translator import WorkflowTranslator
     "to_fmt",
     "--to",
     help="Format of the output file.",
-    type=click.Choice(["drone"]),
+    type=click.Choice(["drone", "task"]),
     default="drone",
 )
 @pass_context
 def cli(ctx, from_fmt, file, to_fmt):
     if to_fmt == "drone":
         outfile = ".drone.yml"
+    elif to_fmt == "task":
+        outfile = "Taskfile.yml"
     translator = WorkflowTranslator.get_translator(to_fmt)
     wf = WorkflowParser.parse(file=file)
     try:

--- a/src/popper/translators/translator.py
+++ b/src/popper/translators/translator.py
@@ -1,6 +1,5 @@
 class WorkflowTranslator(object):
     """Base class for translators."""
-
     def __init__(self):
         pass
 
@@ -10,8 +9,11 @@ class WorkflowTranslator(object):
     @staticmethod
     def get_translator(service_name):
         from popper.translators.translator_drone import DroneTranslator
+        from popper.translators.translator_task import TaskTranslator
 
         if service_name == "drone":
             return DroneTranslator()
+        elif service_name == "task":
+            return TaskTranslator()
         else:
             raise Exception(f"Unknown service {service_name}")

--- a/src/popper/translators/translator.py
+++ b/src/popper/translators/translator.py
@@ -1,5 +1,6 @@
 class WorkflowTranslator(object):
     """Base class for translators."""
+
     def __init__(self):
         pass
 

--- a/src/popper/translators/translator_task.py
+++ b/src/popper/translators/translator_task.py
@@ -1,5 +1,11 @@
 from box.box import Box
 from popper.translators.translator import WorkflowTranslator
+from shlex import quote
+
+
+# helper function to quote and join strings
+def join(lst):
+    return " ".join(quote(arg) for arg in lst)
 
 
 class TaskTranslator(WorkflowTranslator):
@@ -7,5 +13,82 @@ class TaskTranslator(WorkflowTranslator):
         super().__init__()
 
     def translate(self, wf):
-        box = Box(version="3")
+        box = Box(version="3", tasks={}, vars={"PWD": {"sh": "pwd"}})
+
+        # translate each step
+        for step in wf["steps"]:
+            box["tasks"][step["id"]] = self._translate_step(step)
+
+        # call steps in order from default task
+        box["tasks"]["default"] = [{
+            "task": step["id"]
+        } for step in wf["steps"]]
+
         return box.to_yaml()
+
+    # translate a step
+    def _translate_step(self, step):
+        t = self._detect_type(step["uses"])
+        if t == "docker":
+            return self._translate_docker_step(step)
+        elif t == "sh":
+            return self._translate_sh_step(step)
+
+    # detect step type (docker or exec)
+    def _detect_type(self, uses):
+        if "docker://" in uses:
+            return "docker"
+        if uses == "sh":
+            return "sh"
+        raise AttributeError(
+            f"Unexpected value {uses} found in `uses` attribute")
+
+    # translate Popper steps to be executed on host
+    def _translate_sh_step(self, step):
+        task = Box()
+        task["cmds"] = [join(step["runs"] + step["args"])]
+        return task
+
+    def _translate_docker_step(self, step):
+        task = Box()
+
+        # get the name of the docker image
+        image = self._get_docker_image(step["uses"])
+
+        # if `runs` is specified, override the entrypoint
+        # --entrypoint can only take one component. append the rest to command_args
+        # if not specified, set to None
+        entrypoint = f"--entrypoint {quote(step['runs'][0])}" if step[
+            "runs"] else None
+
+        # [COMMAND] [ARG]...
+        command_args = []
+        if step["runs"]:
+            # if `runs` is specified, take the second and later arguments
+            command_args = command_args + list(step['runs'][1:])
+        if step["args"]:
+            # if `args` is specified, append to the list
+            command_args = command_args + list(step['args'])
+
+        # use specified value or default value
+        workdir = step["dir"] if step["dir"] else "/workspace"
+
+        # Falsy values (e.g. None, []) will be omitted
+        command = [
+            "docker", "run", "--rm", "-i", "--volume {{.PWD}}:/workspace",
+            f"--workdir {workdir}", entrypoint, image,
+            join(command_args)
+        ]
+
+        # omit falsy values and join without escapes
+        task["cmds"] = [" ".join([i for i in command if i])]
+        return task
+
+    # takes a `uses` value and returns the name of the docker image
+    def _get_docker_image(self, uses):
+        if "docker://" not in uses:
+            raise AttributeError(
+                "Only docker images are supported for Drone workflow translation"
+            )
+        img = uses.replace("docker://", "")
+        return img

--- a/src/popper/translators/translator_task.py
+++ b/src/popper/translators/translator_task.py
@@ -1,0 +1,11 @@
+from box.box import Box
+from popper.translators.translator import WorkflowTranslator
+
+
+class TaskTranslator(WorkflowTranslator):
+    def __init__(self):
+        super().__init__()
+
+    def translate(self, wf):
+        box = Box(version="3")
+        return box.to_yaml()

--- a/src/popper/translators/translator_task.py
+++ b/src/popper/translators/translator_task.py
@@ -4,7 +4,7 @@ from shlex import quote
 
 
 # helper function to quote and join strings
-def join(lst):
+def quoteJoin(lst):
     return " ".join(quote(arg) for arg in lst)
 
 
@@ -48,7 +48,9 @@ class TaskTranslator(WorkflowTranslator):
         if "runs" not in step:
             # sh steps require `runs` attribute
             raise AttributeError("Expecting 'runs' attribute in step.")
-        task["cmds"] = [join(step["runs"] + (step["args"] if "args" in step else []))]
+        task["cmds"] = [
+            quoteJoin(step["runs"] + (step["args"] if "args" in step else []))
+        ]
         return task
 
     def _translate_docker_step(self, step):
@@ -86,7 +88,7 @@ class TaskTranslator(WorkflowTranslator):
             f"--workdir {workdir}",
             entrypoint,
             image,
-            join(command_args),
+            quoteJoin(command_args),
         ]
 
         # omit falsy values and join without escapes

--- a/src/test/test_translator_task.py
+++ b/src/test/test_translator_task.py
@@ -1,0 +1,203 @@
+from box import Box
+
+from popper.translators.translator_task import TaskTranslator
+from .test_common import PopperTest
+
+
+class TestTaskTranslator(PopperTest):
+    def test_detect_type(self):
+        tt = TaskTranslator()
+        self.assertEqual(tt._detect_type("docker://alpine"), "docker")
+        self.assertEqual(tt._detect_type("docker://alpine:latest"), "docker")
+        self.assertEqual(tt._detect_type("sh"), "sh")
+        with self.assertRaises(AttributeError):
+            tt._detect_type("unknown")
+
+    def test_translate_sh_step(self):
+        tt = TaskTranslator()
+        self.assertEqual(
+            tt._translate_sh_step(
+                Box({
+                    "id": "id",
+                    "uses": "sh",
+                    "runs": ["echo"],
+                    "args": ["hello world"],
+                })),
+            Box({"cmds": ["echo 'hello world'"]}),
+        )
+        # missing `runs`
+        with self.assertRaises(AttributeError):
+            tt._translate_sh_step(
+                Box({
+                    "id": "id",
+                    "uses": "sh",
+                    "args": ["hello"]
+                }))
+        # without args
+        self.assertEqual(
+            tt._translate_sh_step(Box(id="id", uses="sh", runs=["echo"])),
+            Box({"cmds": ["echo"]}),
+        )
+
+    def test_get_docker_image(self):
+        tt = TaskTranslator()
+        # image name only
+        self.assertEqual(tt._get_docker_image("docker://alpine"), "alpine")
+        # image name + tag
+        self.assertEqual(tt._get_docker_image("docker://alpine:latest"),
+                         "alpine:latest")
+        # path to the directly (not supported)
+        with self.assertRaises(AttributeError):
+            tt._get_docker_image("./path/to/dir")
+
+    def test_translate_docker_step(self):
+        tt = TaskTranslator()
+        # minimum
+        self.assertEqual(
+            tt._translate_docker_step(
+                Box({
+                    "id": "id",
+                    "uses": "docker://hello-world",
+                })),
+            Box({
+                "cmds": [
+                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace hello-world"
+                ],
+            }),
+        )
+        # args
+        self.assertEqual(
+            tt._translate_docker_step(
+                Box({
+                    "id": "id",
+                    "uses": "docker://node:14",
+                    "args": ["index.js"]
+                })),
+            Box({
+                "cmds": [
+                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace node:14 index.js"
+                ],
+            }),
+        )
+        # runs
+        self.assertEqual(
+            tt._translate_docker_step(
+                Box({
+                    "id": "id",
+                    "uses": "docker://alpine",
+                    "runs": ["echo"],
+                    "args": ["hello world"],
+                })),
+            Box({
+                "cmds": [
+                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace --entrypoint echo alpine 'hello world'"
+                ],
+            }),
+        )
+        # runs (two or more elements)
+        self.assertEqual(
+            tt._translate_docker_step(
+                Box({
+                    "id": "id",
+                    "uses": "docker://alpine",
+                    "runs": ["/bin/sh", "-c"],
+                    "args": ["echo hello world"],
+                })),
+            Box({
+                "cmds": [
+                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace --entrypoint /bin/sh alpine -c 'echo hello world'"
+                ],
+            }),
+        )
+        # workdir
+        self.assertEqual(
+            tt._translate_docker_step(
+                Box({
+                    "id": "id",
+                    "uses": "docker://hello-world",
+                    "dir": "/tmp"
+                })),
+            Box({
+                "cmds": [
+                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /tmp hello-world"
+                ],
+            }),
+        )
+
+    def test_translate(self):
+        tt = TaskTranslator()
+
+        popper_wf_sh = Box({
+            "steps": [{
+                "id":
+                "download",
+                "uses":
+                "sh",
+                "runs": ["curl"],
+                "args": [
+                    "-LO",
+                    "https://github.com/datasets/co2-fossil-global/raw/master/global.csv",
+                ],
+            }],
+        })
+        task_sh = tt.translate(popper_wf_sh)
+        self.assertEqual(
+            Box.from_yaml(task_sh),
+            Box({
+                "version": "3",
+                "vars": {
+                    "PWD": {
+                        "sh": "pwd"
+                    }
+                },
+                "tasks": {
+                    "default": {
+                        "cmds": [{
+                            "task": "download"
+                        }]
+                    },
+                    "download": {
+                        "cmds": [
+                            "curl -LO https://github.com/datasets/co2-fossil-global/raw/master/global.csv"
+                        ]
+                    },
+                },
+            }),
+        )
+
+        popper_wf_docker = Box({
+            "steps": [{
+                "id":
+                "download",
+                "uses":
+                "docker://byrnedo/alpine-curl:0.1.8",
+                "args": [
+                    "-LO",
+                    "https://github.com/datasets/co2-fossil-global/raw/master/global.csv",
+                ],
+            }],
+        })
+        task_docker = tt.translate(popper_wf_docker)
+        self.assertEqual(
+            Box.from_yaml(task_docker),
+            Box({
+                "version": "3",
+                "vars": {
+                    "PWD": {
+                        "sh": "pwd"
+                    }
+                },
+                "tasks": {
+                    "default": {
+                        "cmds": [{
+                            "task": "download"
+                        }]
+                    },
+                    "download": {
+                        "cmds": [
+                            "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace byrnedo/alpine-curl:0.1.8 -LO https://github.com/datasets/co2-fossil-global/raw/master/global.csv"
+                        ]
+                    },
+                },
+            }),
+        )

--- a/src/test/test_translator_task.py
+++ b/src/test/test_translator_task.py
@@ -17,22 +17,20 @@ class TestTaskTranslator(PopperTest):
         tt = TaskTranslator()
         self.assertEqual(
             tt._translate_sh_step(
-                Box({
-                    "id": "id",
-                    "uses": "sh",
-                    "runs": ["echo"],
-                    "args": ["hello world"],
-                })),
+                Box(
+                    {
+                        "id": "id",
+                        "uses": "sh",
+                        "runs": ["echo"],
+                        "args": ["hello world"],
+                    }
+                )
+            ),
             Box({"cmds": ["echo 'hello world'"]}),
         )
         # missing `runs`
         with self.assertRaises(AttributeError):
-            tt._translate_sh_step(
-                Box({
-                    "id": "id",
-                    "uses": "sh",
-                    "args": ["hello"]
-                }))
+            tt._translate_sh_step(Box({"id": "id", "uses": "sh", "args": ["hello"]}))
         # without args
         self.assertEqual(
             tt._translate_sh_step(Box(id="id", uses="sh", runs=["echo"])),
@@ -44,8 +42,9 @@ class TestTaskTranslator(PopperTest):
         # image name only
         self.assertEqual(tt._get_docker_image("docker://alpine"), "alpine")
         # image name + tag
-        self.assertEqual(tt._get_docker_image("docker://alpine:latest"),
-                         "alpine:latest")
+        self.assertEqual(
+            tt._get_docker_image("docker://alpine:latest"), "alpine:latest"
+        )
         # path to the directly (not supported)
         with self.assertRaises(AttributeError):
             tt._get_docker_image("./path/to/dir")
@@ -55,149 +54,149 @@ class TestTaskTranslator(PopperTest):
         # minimum
         self.assertEqual(
             tt._translate_docker_step(
-                Box({
-                    "id": "id",
-                    "uses": "docker://hello-world",
-                })),
-            Box({
-                "cmds": [
-                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace hello-world"
-                ],
-            }),
+                Box({"id": "id", "uses": "docker://hello-world",})
+            ),
+            Box(
+                {
+                    "cmds": [
+                        "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace hello-world"
+                    ],
+                }
+            ),
         )
         # args
         self.assertEqual(
             tt._translate_docker_step(
-                Box({
-                    "id": "id",
-                    "uses": "docker://node:14",
-                    "args": ["index.js"]
-                })),
-            Box({
-                "cmds": [
-                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace node:14 index.js"
-                ],
-            }),
+                Box({"id": "id", "uses": "docker://node:14", "args": ["index.js"]})
+            ),
+            Box(
+                {
+                    "cmds": [
+                        "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace node:14 index.js"
+                    ],
+                }
+            ),
         )
         # runs
         self.assertEqual(
             tt._translate_docker_step(
-                Box({
-                    "id": "id",
-                    "uses": "docker://alpine",
-                    "runs": ["echo"],
-                    "args": ["hello world"],
-                })),
-            Box({
-                "cmds": [
-                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace --entrypoint echo alpine 'hello world'"
-                ],
-            }),
+                Box(
+                    {
+                        "id": "id",
+                        "uses": "docker://alpine",
+                        "runs": ["echo"],
+                        "args": ["hello world"],
+                    }
+                )
+            ),
+            Box(
+                {
+                    "cmds": [
+                        "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace --entrypoint echo alpine 'hello world'"
+                    ],
+                }
+            ),
         )
         # runs (two or more elements)
         self.assertEqual(
             tt._translate_docker_step(
-                Box({
-                    "id": "id",
-                    "uses": "docker://alpine",
-                    "runs": ["/bin/sh", "-c"],
-                    "args": ["echo hello world"],
-                })),
-            Box({
-                "cmds": [
-                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace --entrypoint /bin/sh alpine -c 'echo hello world'"
-                ],
-            }),
+                Box(
+                    {
+                        "id": "id",
+                        "uses": "docker://alpine",
+                        "runs": ["/bin/sh", "-c"],
+                        "args": ["echo hello world"],
+                    }
+                )
+            ),
+            Box(
+                {
+                    "cmds": [
+                        "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace --entrypoint /bin/sh alpine -c 'echo hello world'"
+                    ],
+                }
+            ),
         )
         # workdir
         self.assertEqual(
             tt._translate_docker_step(
-                Box({
-                    "id": "id",
-                    "uses": "docker://hello-world",
-                    "dir": "/tmp"
-                })),
-            Box({
-                "cmds": [
-                    "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /tmp hello-world"
-                ],
-            }),
+                Box({"id": "id", "uses": "docker://hello-world", "dir": "/tmp"})
+            ),
+            Box(
+                {
+                    "cmds": [
+                        "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /tmp hello-world"
+                    ],
+                }
+            ),
         )
 
     def test_translate(self):
         tt = TaskTranslator()
 
-        popper_wf_sh = Box({
-            "steps": [{
-                "id":
-                "download",
-                "uses":
-                "sh",
-                "runs": ["curl"],
-                "args": [
-                    "-LO",
-                    "https://github.com/datasets/co2-fossil-global/raw/master/global.csv",
+        popper_wf_sh = Box(
+            {
+                "steps": [
+                    {
+                        "id": "download",
+                        "uses": "sh",
+                        "runs": ["curl"],
+                        "args": [
+                            "-LO",
+                            "https://github.com/datasets/co2-fossil-global/raw/master/global.csv",
+                        ],
+                    }
                 ],
-            }],
-        })
+            }
+        )
         task_sh = tt.translate(popper_wf_sh)
         self.assertEqual(
             Box.from_yaml(task_sh),
-            Box({
-                "version": "3",
-                "vars": {
-                    "PWD": {
-                        "sh": "pwd"
-                    }
-                },
-                "tasks": {
-                    "default": {
-                        "cmds": [{
-                            "task": "download"
-                        }]
+            Box(
+                {
+                    "version": "3",
+                    "vars": {"PWD": {"sh": "pwd"}},
+                    "tasks": {
+                        "default": {"cmds": [{"task": "download"}]},
+                        "download": {
+                            "cmds": [
+                                "curl -LO https://github.com/datasets/co2-fossil-global/raw/master/global.csv"
+                            ]
+                        },
                     },
-                    "download": {
-                        "cmds": [
-                            "curl -LO https://github.com/datasets/co2-fossil-global/raw/master/global.csv"
-                        ]
-                    },
-                },
-            }),
+                }
+            ),
         )
 
-        popper_wf_docker = Box({
-            "steps": [{
-                "id":
-                "download",
-                "uses":
-                "docker://byrnedo/alpine-curl:0.1.8",
-                "args": [
-                    "-LO",
-                    "https://github.com/datasets/co2-fossil-global/raw/master/global.csv",
+        popper_wf_docker = Box(
+            {
+                "steps": [
+                    {
+                        "id": "download",
+                        "uses": "docker://byrnedo/alpine-curl:0.1.8",
+                        "args": [
+                            "-LO",
+                            "https://github.com/datasets/co2-fossil-global/raw/master/global.csv",
+                        ],
+                    }
                 ],
-            }],
-        })
+            }
+        )
         task_docker = tt.translate(popper_wf_docker)
         self.assertEqual(
             Box.from_yaml(task_docker),
-            Box({
-                "version": "3",
-                "vars": {
-                    "PWD": {
-                        "sh": "pwd"
-                    }
-                },
-                "tasks": {
-                    "default": {
-                        "cmds": [{
-                            "task": "download"
-                        }]
+            Box(
+                {
+                    "version": "3",
+                    "vars": {"PWD": {"sh": "pwd"}},
+                    "tasks": {
+                        "default": {"cmds": [{"task": "download"}]},
+                        "download": {
+                            "cmds": [
+                                "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace byrnedo/alpine-curl:0.1.8 -LO https://github.com/datasets/co2-fossil-global/raw/master/global.csv"
+                            ]
+                        },
                     },
-                    "download": {
-                        "cmds": [
-                            "docker run --rm -i --volume {{.PWD}}:/workspace --workdir /workspace byrnedo/alpine-curl:0.1.8 -LO https://github.com/datasets/co2-fossil-global/raw/master/global.csv"
-                        ]
-                    },
-                },
-            }),
+                }
+            ),
         )


### PR DESCRIPTION
## Overview

This PR adds `TaskTranslator`, the class that translates popper workflows to [Taskfile](https://taskfile.dev/). Because Task does not provide container support, the translator generates `docker run` commands if the workflow specifies a Docker container as a runtime.

This is an early version and not all features are implemented. See `Next Action` for details.

## Translation

The `tasks` attribute in Taskfile is an object where its keys are task names. On the other hand, `steps` in Popper is an array and each step has an ID. 

When you run the `task` command without specifying the task name, it will attempt to run the task named `default`. Because we expect Task to run the commands in order, the translator automatically generates `default` task that calls other tasks in order.

For example, the translation of 

```yaml
steps:
  - id: build
    ...
  - id: test
    ...
```

will be

```yaml
tasks:
  default:
    cmds:
      - task: build
      - task: test
  build:
    ...
  test:
    ...
```

Translation of Popper steps with `uses: sh` is quite simple. We create a command by concatenating `runs` and `args` attributes with appropriate escapes and pass it to `cmds`.

Popper steps that use Docker images will be translated to `docker run` commands. The translator will add appropriate flags (such as `--entrypoint`, `--workspace`, `--volume`) to simulate the behavior of Popper.

## Next Action

We need to work on the following things to make this translator stable and useful.

- Integration Test
- Name collision prevention (support Popper steps whose ID is `default`)
- Environment variables support
