### PR TITLE
Translator: setup task integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           echo "ENABLE_SLURM_RUNNER_TESTS=1" >> $GITHUB_ENV
           echo "ENABLE_K8S_RUNNER_TESTS=1" >> $GITHUB_ENV
           echo "ENABLE_DRONE_TRANSLATOR_TESTS=1" >> $GITHUB_ENV
+          echo "ENABLE_TASK_TRANSLATOR_TESTS=1" >> $GITHUB_ENV
         fi
 
     - name: set up python ${{ matrix.python-version }}
@@ -35,6 +36,7 @@ jobs:
         src/scripts/install_podman.sh
         src/scripts/install_singularity.sh
         src/scripts/install_drone.sh
+        src/scripts/install_task.sh
         python -m pip install --upgrade pip
         pip install coverage
         pip install -e src/[dev]
@@ -50,6 +52,7 @@ jobs:
     - name: test-integration
       run: |
         src/test/integration/test_translator_drone.sh
+        src/test/integration/test_translator_task.sh
 
     - name: package
       env:

--- a/src/scripts/install_task.sh
+++ b/src/scripts/install_task.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+if [[ -z $ENABLE_TASK_TRANSLATOR_TESTS ]]; then
+  exit 0
+fi
+
+# install task
+sudo sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin

--- a/src/test/integration/test_translator_task.sh
+++ b/src/test/integration/test_translator_task.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -ex
+
+if [[ -z $ENABLE_TASK_TRANSLATOR_TESTS ]]; then
+  exit 0
+fi
+
+marker="POPPER-TASK-TRANSLATION"
+filename="out.txt"
+
+# create and cd into a workspace
+tmp_dir=$(mktemp -d)
+cd $tmp_dir
+
+# create a popper workflow
+cat << EOT >> wf.yml
+steps:
+  - runs:
+    uses: docker://alpine
+    runs:
+      [/bin/sh]
+    args: [-c, 'echo $marker > $filename']
+EOT
+
+# clean the output
+rm -f $filename
+
+# translate the workflow
+popper translate -f wf.yml --to task
+
+# execute the workflow with Drone and check the result
+task
+if ! cat ./$filename | grep -q $marker; then
+  >&2 echo "Failed to find the marker in the task output"
+  exit 1
+fi
+
+echo "Task generated a correct file from the translated workflow"
+exit 0


### PR DESCRIPTION
This PR adds integration tests that ensure popper-to-task conversion correctly generates a valid Taskfile.

When testing the Docker engine on CI, we set `ENABLE_TASK_TRANSLATOR_TESTS` flag, which will 1) install task CLI and 2) run the integration test script.

The purpose of this test is to verify the validity of the files generated by the command, and the rest of the translation process will be covered by unit tests.