### PR TITLE
translator: support `env` options in Popper-to-Task translator

### DIFF
--- a/src/popper/translators/translator_task.py
+++ b/src/popper/translators/translator_task.py
@@ -72,6 +72,8 @@ class TaskTranslator(WorkflowTranslator):
         task["cmds"] = [
             quoteJoin(step["runs"] + (step["args"] if "args" in step else []))
         ]
+        if "env" in step:
+            task["env"] = step["env"]
         return task
 
     def _translate_docker_step(self, step, env):

--- a/src/popper/translators/translator_task.py
+++ b/src/popper/translators/translator_task.py
@@ -98,12 +98,13 @@ class TaskTranslator(WorkflowTranslator):
 
         # get environment variables available in this step
         # both workflow-wide variables and step-specific variables are available thanks to the parser
-        step_env = step["env"]
+        step_env = step["env"] if "env" in step else {}
 
         # a list of environment variables available in this context
-        env_list = ({**step_env, **env}).keys()
+        # sort the keys for readability and testability
+        env_list = sorted(({**step_env, **env}).keys())
         # --env flags that make environment variables in Docker
-        env_opt = " ".join(map(lambda varname: f"--env {varname}", env_list))
+        env_opt = " ".join([f"--env {varname}" for varname in env_list])
 
         # use specified value or default value
         workdir = step["dir"] if "dir" in step else "/workspace"
@@ -125,7 +126,8 @@ class TaskTranslator(WorkflowTranslator):
         # omit falsy values and join without escapes
         task["cmds"] = [" ".join([i for i in command if i])]
 
-        task["env"] = step_env
+        if step_env:
+            task["env"] = step_env
         return task
 
     # takes a `uses` value and returns the name of the docker image

--- a/src/popper/translators/translator_task.py
+++ b/src/popper/translators/translator_task.py
@@ -17,15 +17,19 @@ class TaskTranslator(WorkflowTranslator):
 
         box["vars"] = {
             "PWD": {"sh": "pwd"},
-            "GIT_COMMIT": {"sh": "git rev-parse HEAD"},
-            "GIT_BRANCH": {"sh": "git branch --show-current"},
-            "GIT_SHA_SHORT": {"sh": "git rev-parse --short HEAD"},
+            # redirect stderr to /dev/null to supress warning if the directory is not a git repo
+            "GIT_COMMIT": {"sh": 'git rev-parse HEAD || echo ""'},
+            "GIT_BRANCH": {"sh": 'git branch --show-current 2>/dev/null || echo ""'},
+            "GIT_SHA_SHORT": {
+                "sh": 'git rev-parse --short HEAD 2>/dev/null || echo ""'
+            },
             "GIT_REMOTE_ORIGIN_URL": {
                 # git config --get exists with non-zero code if the config is not set.
                 # if the remote origin url is not set, set the empty string
+                # no need for redirect since it doesn't generate an error message
                 "sh": 'git config --get remote.origin.url || echo ""'
             },
-            "GIT_TAG": {"sh": "git tag -l --contains HEAD | head -n 1"},
+            "GIT_TAG": {"sh": "git tag -l --contains HEAD 2>/dev/null | head -n 1"},
         }
 
         box["env"] = {

--- a/src/popper/translators/translator_task.py
+++ b/src/popper/translators/translator_task.py
@@ -13,11 +13,32 @@ class TaskTranslator(WorkflowTranslator):
         super().__init__()
 
     def translate(self, wf):
-        box = Box(version="3", tasks={}, vars={"PWD": {"sh": "pwd"}})
+        box = Box(version="3", tasks={}, vars={})
+
+        box["vars"] = {
+            "PWD": {"sh": "pwd"},
+            "GIT_COMMIT": {"sh": "git rev-parse HEAD"},
+            "GIT_BRANCH": {"sh": "git branch --show-current"},
+            "GIT_SHA_SHORT": {"sh": "git rev-parse --short HEAD"},
+            "GIT_REMOTE_ORIGIN_URL": {
+                # git config --get exists with non-zero code if the config is not set.
+                # if the remote origin url is not set, set the empty string
+                "sh": 'git config --get remote.origin.url || echo ""'
+            },
+            "GIT_TAG": {"sh": "git tag -l --contains HEAD | head -n 1"},
+        }
+
+        box["env"] = {
+            "GIT_COMMIT": "{{.GIT_COMMIT}}",
+            "GIT_BRANCH": "{{.GIT_BRANCH}}",
+            "GIT_SHA_SHORT": "{{.GIT_SHA_SHORT}}",
+            "GIT_REMOTE_ORIGIN_URL": "{{.GIT_REMOTE_ORIGIN_URL}}",
+            "GIT_TAG": "{{.GIT_TAG}}",
+        }
 
         # translate each step
         for step in wf["steps"]:
-            box["tasks"][step["id"]] = self._translate_step(step)
+            box["tasks"][step["id"]] = self._translate_step(step, box["env"])
 
         # call steps in order from default task
         box["tasks"]["default"] = {
@@ -27,10 +48,10 @@ class TaskTranslator(WorkflowTranslator):
         return box.to_yaml()
 
     # translate a step
-    def _translate_step(self, step):
+    def _translate_step(self, step, env):
         t = self._detect_type(step["uses"])
         if t == "docker":
-            return self._translate_docker_step(step)
+            return self._translate_docker_step(step, env)
         elif t == "sh":
             return self._translate_sh_step(step)
 
@@ -53,7 +74,7 @@ class TaskTranslator(WorkflowTranslator):
         ]
         return task
 
-    def _translate_docker_step(self, step):
+    def _translate_docker_step(self, step, env):
         task = Box()
 
         # get the name of the docker image
@@ -75,6 +96,15 @@ class TaskTranslator(WorkflowTranslator):
             # if `args` is specified, append to the list
             command_args = command_args + list(step["args"])
 
+        # get environment variables available in this step
+        # both workflow-wide variables and step-specific variables are available thanks to the parser
+        step_env = step["env"]
+
+        # a list of environment variables available in this context
+        env_list = ({**step_env, **env}).keys()
+        # --env flags that make environment variables in Docker
+        env_opt = " ".join(map(lambda varname: f"--env {varname}", env_list))
+
         # use specified value or default value
         workdir = step["dir"] if "dir" in step else "/workspace"
 
@@ -82,6 +112,7 @@ class TaskTranslator(WorkflowTranslator):
         command = [
             "docker",
             "run",
+            env_opt,
             "--rm",
             "-i",
             "--volume {{.PWD}}:/workspace",
@@ -93,6 +124,8 @@ class TaskTranslator(WorkflowTranslator):
 
         # omit falsy values and join without escapes
         task["cmds"] = [" ".join([i for i in command if i])]
+
+        task["env"] = step_env
         return task
 
     # takes a `uses` value and returns the name of the docker image

--- a/src/test/test_translator_task.py
+++ b/src/test/test_translator_task.py
@@ -6,13 +6,13 @@ from .test_common import PopperTest
 
 class TestTaskTranslator(PopperTest):
     GIT_VARS = {
-        "GIT_COMMIT": {"sh": "git rev-parse HEAD"},
-        "GIT_BRANCH": {"sh": "git branch --show-current"},
-        "GIT_SHA_SHORT": {"sh": "git rev-parse --short HEAD"},
+        "GIT_COMMIT": {"sh": 'git rev-parse HEAD || echo ""'},
+        "GIT_BRANCH": {"sh": 'git branch --show-current 2>/dev/null || echo ""'},
+        "GIT_SHA_SHORT": {"sh": 'git rev-parse --short HEAD 2>/dev/null || echo ""'},
         "GIT_REMOTE_ORIGIN_URL": {
             "sh": 'git config --get remote.origin.url || echo ""'
         },
-        "GIT_TAG": {"sh": "git tag -l --contains HEAD | head -n 1"},
+        "GIT_TAG": {"sh": "git tag -l --contains HEAD 2>/dev/null | head -n 1"},
     }
     GIT_ENV = {
         "GIT_COMMIT": "{{.GIT_COMMIT}}",
@@ -110,7 +110,7 @@ class TestTaskTranslator(PopperTest):
                     }
                 ),
                 TestTaskTranslator.GIT_ENV,
-            ).to_dict(),
+            ),
             Box(
                 {
                     "cmds": [
@@ -118,7 +118,7 @@ class TestTaskTranslator(PopperTest):
                     ],
                     "env": {"FOO": "foo", "BAR": "bar"},
                 }
-            ).to_dict(),
+            ),
         )
         # runs
         self.assertEqual(


### PR DESCRIPTION
## Overview

This PR adds support for `env` options in Popper-to-Task translator.

It adds the following two functionalities to the translator.

- make environment variables defined in the Popper workflow available
- make the pre-defined variables (e.g. `GIT_COMMIT`) available

## User-defined environment variables

Popper provides two ways to define environment variables.

The first is to use the `options.env` attribute. The environment variables defined in this attribute would be available from all steps in the workflow.

The second is to use the `steps[i].env` attribute. The variables defined in this attribute are only available in the step.

When the Popper parser parses a workflow, it automatically reads variables defined in `options.env` and merges them into `steps[i].env`. 

Therefore, the Popper-to-Task translator reads that merged dictionary (consists of `options.env` and `steps[i].env`) and put it in `task[i].env`. Task will read the attribute and the variables will be accessible from the commands.

## Pre-defined environment variables

Popper provides five pre-defined variables (`GIT_COMMIT`, `GIT_BRANCH`, `GIT_SHA_SHORT`, `GIT_REMOTE_ORIGIN_URL`, `GIT_TAG`) that users can use in their workflows. Unlike Drone, Task doesn't have any pre-defined variables, hence we need to run commands and define variables.

I used [Task's dynamic variables](https://taskfile.dev/#/usage?id=dynamic-variables). As shown in Task's documentation, Task can run commands and replace placeholders (e.g. `{{.VAR_NAME}}`) with their results.

Because the `env` attribute can contain such placeholders, we can 1) define dynamic variables and 2) use these variables to define environment variables.

The below is an example output of the translator.

```yaml
env:
  GIT_BRANCH: '{{.GIT_BRANCH}}'
  GIT_COMMIT: '{{.GIT_COMMIT}}'
  GIT_REMOTE_ORIGIN_URL: '{{.GIT_REMOTE_ORIGIN_URL}}'
  GIT_SHA_SHORT: '{{.GIT_SHA_SHORT}}'
  GIT_TAG: '{{.GIT_TAG}}'
vars:
  GIT_BRANCH:
    sh: git branch --show-current 2>/dev/null || echo ""
  GIT_COMMIT:
    sh: git rev-parse HEAD || echo ""
  GIT_REMOTE_ORIGIN_URL:
    sh: git config --get remote.origin.url || echo ""
  GIT_SHA_SHORT:
    sh: git rev-parse --short HEAD 2>/dev/null || echo ""
  GIT_TAG:
    sh: git tag -l --contains HEAD 2>/dev/null | head -n 1
```

`vars` will define dynamic variables and we use these variables in `env` to expose them from environment variables.

## Exposing Environment Variables to Docker Containers

Task will make environment variables available to the commands it runs. They won't be available from Docker containers unless we tell Docker which environment variables can be read from inside containers.

The translator will generate options (e.g. `--env {VAR1} --env {VAR2} ...`) and use the flags to run `docker run` command.
