### PR TITLE
Document Popper-to-Task Translator

### DIFF
--- a/docs/sections/cli_features.md
+++ b/docs/sections/cli_features.md
@@ -278,10 +278,20 @@ The `translate` subcommand supports [Drone CI](https://www.drone.io/). The comma
 
 Restrictions on translation are as follows:
 
-- Running commands on Docker and Host machine is supported. Singularity and podmand are not supported.
+- Running commands on Docker and Host machine is supported. Singularity and Podman are not supported.
 - All steps in a workflow must use either Docker or the host machine. The two cannot be combined in a single workflow.
 - Only pre-built Docker images can be used. Workflows that specify the directory where the Dockerfile is located in the `uses` attribute cannot be translated.
 - If you specify the `dir` attribute, you must also specify the `runs` attribute.
+
+### Task
+
+The `translate` subcommand supports [Task](https://taskfile.dev/). The command converts a Popper workflow to a Taskfile.
+
+Restrictions on translation are as follows:
+
+- Running commands on Docker and Host machine is supported. Singularity and Podman are not supported.
+- Only pre-built Docker images can be used. Workflows that specify the directory where the Dockerfile is located in the `uses` attribute cannot be translated.
+- The Popper workflow to translate must not have a step with an ID of `default`
 
 ## Visualizing workflows
 

--- a/src/popper/translators/translator_task.py
+++ b/src/popper/translators/translator_task.py
@@ -42,6 +42,11 @@ class TaskTranslator(WorkflowTranslator):
 
         # translate each step
         for step in wf["steps"]:
+            step_id = step["id"]
+            if step_id == "default":
+                raise AttributeError(
+                    f"'default' cannot be used as a step ID when translating Popper to Task."
+                )
             box["tasks"][step["id"]] = self._translate_step(step, box["env"])
 
         # call steps in order from default task
@@ -140,7 +145,7 @@ class TaskTranslator(WorkflowTranslator):
     def _get_docker_image(self, uses):
         if "docker://" not in uses:
             raise AttributeError(
-                "Only docker images are supported for Drone workflow translation"
+                "Only docker images are supported for Task workflow translation"
             )
         img = uses.replace("docker://", "")
         return img

--- a/src/test/test_translator_task.py
+++ b/src/test/test_translator_task.py
@@ -179,6 +179,24 @@ class TestTaskTranslator(PopperTest):
     def test_translate(self):
         tt = TaskTranslator()
 
+        popper_wf_with_step_default = Box(
+            {
+                "steps": [
+                    {
+                        "id": "default",
+                        "uses": "sh",
+                        "runs": ["curl"],
+                        "args": [
+                            "-LO",
+                            "https://github.com/datasets/co2-fossil-global/raw/master/global.csv",
+                        ],
+                    }
+                ],
+            }
+        )
+        with self.assertRaises(AttributeError):
+            tt.translate(popper_wf_with_step_default)
+
         popper_wf_sh = Box(
             {
                 "steps": [


### PR DESCRIPTION
This PR adds documentation for Popper-to-Task translator. 

It also makes changes to Popper-to-Task translator to raise an error if the source popper workflow contains a step whose id is `default`, which conflicts with the Task's reserved name.
